### PR TITLE
Feature/test emreparser

### DIFF
--- a/stellacanread-proxy/src/main/java/com/ste/emreparser/MessageObject.java
+++ b/stellacanread-proxy/src/main/java/com/ste/emreparser/MessageObject.java
@@ -1,25 +1,25 @@
 package com.ste.emreparser;
 
 /**
- * This class stores a single message that was parsed from 
+ * This class stores a single message that was parsed from
  * a "CAN_overview_2019_17-format.csv" file
- * 
- * A single message consists of 16 different fields, which are the following: 
- * id - name - DataNames - DataTypes - DataUnits - Standard Values - Log - PutToCan1 - PutToCan2 - 
+ *
+ * A single message consists of 16 different fields, which are the following:
+ * id - name - DataNames - DataTypes - DataUnits - Standard Values - Log - PutToCan1 - PutToCan2 -
  * Description - Sender - Receiver - ToStrat - ToVis - NotToDB - Convert Endiannes
- * 
- * These individual fields can be requested by calling the corresponding getter method. 
- * 
- * No additional processing is done on these fields. 
+ *
+ * These individual fields can be requested by calling the corresponding getter method.
+ *
+ * No additional processing is done on these fields.
  */
 
 //TODO: Convert this class to make use of the Builder design pattern
 public class MessageObject {
 
     // Declare all fields as String variables
-    private String id; 
-    private String name; 
-    private String[] fieldNames; 
+    private String id;
+    private String name;
+    private String[] fieldNames;
     private String[] dataTypes;
     private String[] units;
     private String[] defaultValues;
@@ -37,12 +37,12 @@ public class MessageObject {
                          String description, String senders, String receivers, String sendInterval, String convertEndianess,
                          String type, String properties, String sendFrequency) {
         this.id = id;
-        this.name = name; 
+        this.name = name;
         this.fieldNames = fieldNames.split(",");
         this.dataTypes = dataTypes.split(",");
         this.units = units.split(",");
         this.defaultValues = defaultValues.split(",");
-        this.description = description; 
+        this.description = description;
         this.senders = senders.split(",");
         this.receivers = receivers.split(",");
         this.sendInterval = sendInterval;
@@ -50,8 +50,32 @@ public class MessageObject {
         this.type = type;
         this.properties = properties;
         this.sendFrequency = sendFrequency;
+
+        // Remove all the whitespaces from the arrays that exist for this object
+        removeWhitespaces();
     }
 
+    // Remove all whitespaces from arrays that exist for this object
+    private void removeWhitespaces() {
+        for (int i = 0; i < this.fieldNames.length; i++) {
+            this.fieldNames[i] = this.fieldNames[i].trim();
+        }
+        for (int i = 0; i < this.dataTypes.length; i++) {
+            this.dataTypes[i] = this.dataTypes[i].trim();
+        }
+        for (int i = 0; i < this.units.length; i++) {
+            this.units[i] = this.units[i].trim();
+        }
+        for (int i = 0; i < this.defaultValues.length; i++) {
+            this.defaultValues[i] = this.defaultValues[i].trim();
+        }
+        for (int i = 0; i < this.senders.length; i++) {
+            this.senders[i] = this.senders[i].trim();
+        }
+        for (int i = 0; i < this.receivers.length; i++) {
+            this.receivers[i] = this.receivers[i].trim();
+        }
+    }
 
     public void prettyPrint() {
         System.out.println("-------------------------------------------------------");

--- a/stellacanread-proxy/src/main/java/com/ste/emreparser/TypedefObject.java
+++ b/stellacanread-proxy/src/main/java/com/ste/emreparser/TypedefObject.java
@@ -4,16 +4,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * This class stores a single typedef that was parsed from a 
- * "CAN_typedef_2019_17-format.csv" file 
- * 
- * A single typedef line consists of three values: 
- * 
+ * This class stores a single typedef that was parsed from a
+ * "CAN_typedef_2019_17-format.csv" file
+ *
+ * A single typedef line consists of three values:
+ *
  * 1. A name
  * 2. A code
  * 3. A description
- * 
- * These values are stored in this object, together with the individiual states each typedef can take. 
+ *
+ * These values are stored in this object, together with the individiual states each typedef can take.
  */
 public class TypedefObject {
 
@@ -24,7 +24,7 @@ public class TypedefObject {
 
     // We also do some extra parsing to extract more information from the code variable
     private String codeType;
-    private String[] codeStates; 
+    private String[] codeStates;
 
     // Use the constructor to set up a basic instance of a Parsedtypedef object
     public TypedefObject(String name, String code, String description) {
@@ -32,11 +32,11 @@ public class TypedefObject {
         this.name = name;
         this.code = code;
         this.description = description;
-        
+
         // Do some additional parsing for the code variable
         parseCode();
     }
-    
+
     public void prettyPrint() {
         System.out.println("-------------------------------------------------------");
         System.out.println("| Pretty printing all values for " + this.name.toUpperCase());
@@ -53,13 +53,11 @@ public class TypedefObject {
     }
 
     private void parseCode() {
-        // Check for the type 
+        // Check for the type
         if (this.code.contains("uint8_t")) {
             this.codeType = "uint8_t";
-            
-        // TODO: find out if different types exist for the CAN spec
-        } else if (this.code.contains("??")) { 
-
+        }  else {
+            throw new IllegalArgumentException("Type not recognized");
         }
 
         // Extract the states from the code using a regular expression, which have the format "{state1, state2, state3, ...}"
@@ -67,7 +65,7 @@ public class TypedefObject {
         Pattern r = Pattern.compile(pattern);
 
         Matcher m = r.matcher(this.code);
-        
+
         if (m.find())
             this.codeStates = m.group(1).split(",");
 
@@ -75,14 +73,13 @@ public class TypedefObject {
         for (int i = 0; i < codeStates.length; i++) {
             this.codeStates[i] = this.codeStates[i].trim();
         }
-            //TODO: exception handling when format isn't correct
-    }   
+    }
 
     // Some basic getters to retrieve instance variables
     public String[] getCodeStates() {
         return this.codeStates;
     }
-    
+
     public String getCodeType() {
         return this.codeType;
     }
@@ -99,5 +96,5 @@ public class TypedefObject {
         return this.description;
     }
 
-    //TODO: maybe also implement setters for name, code and description 
+    //TODO: maybe also implement setters for name, code and description
 }

--- a/stellacanread-proxy/src/main/java/com/ste/specificationstuff/CANEnumParser.java
+++ b/stellacanread-proxy/src/main/java/com/ste/specificationstuff/CANEnumParser.java
@@ -14,15 +14,15 @@ import java.util.Date;
 import java.util.HashSet;
 
 
-//CONSULT DRIVE FOR EASIER OVERVIEW OF FUNCTIONS - https://drive.google.com/drive/u/0/folders/1vgE6a2_4SK2RJL6YsllVkD5Wmiu9INAC 
+//CONSULT DRIVE FOR EASIER OVERVIEW OF FUNCTIONS - https://drive.google.com/drive/u/0/folders/1vgE6a2_4SK2RJL6YsllVkD5Wmiu9INAC
 
 
-/*Note: Bytes should always be read from left to right. Enums are always represented using a single byte, whereas booleans are represented using a single bit. Integers can be 
-* represented with upto 32 bits. Furthermore, the bytes that represent enums are typically equal to 00, 01, 02, 03 etc in hexadecimal. If a variable has three states it can only 
+/*Note: Bytes should always be read from left to right. Enums are always represented using a single byte, whereas booleans are represented using a single bit. Integers can be
+* represented with upto 32 bits. Furthermore, the bytes that represent enums are typically equal to 00, 01, 02, 03 etc in hexadecimal. If a variable has three states it can only
 * be equal to 00, 01, and 02. Also, enums are allowed to have non-standard byte sequences. In this case STE defines a what the byte sequence of a specific state looks like in the
 * CAN_typedef_2019_17-format.csv file.
 *
-* Examples: 
+* Examples:
 * signal A has 1 boolean that is set to true. The 8 bytes look as follows: 00000001 00000000 00000000 00000000 00000000 00000000 00000000 00000000
 * signal B has 3 booleans in the following order (from top to bottom in CAN-X) true, false, true. 8 bytes: 00000101 00000000 00000000 00000000 00000000 00000000 00000000 00000000
 * signal C has 2 booleans and 1 enum in the following order true true enumState2. 8 bytes: 00000011 00000010 00000000 00000000 00000000 00000000 00000000 00000000
@@ -45,14 +45,14 @@ public class CANEnumParser {
 
     //The actual message we'll eventually need to parse
     static String testmsg = "(1600453413.322000) canx 12d#01c90100a819d400";
-        
+
     //Data part of 'testmsg' (01c90100a819d400) converted to binary: 0001 11001001 00000001 00000000 10101000 00011001 11010100 00000000
-        
-     //These are strings that we will eventually need to deduce using the .csv files and the id of string 'testmsg'. The data types correspond to the following variables: 
+
+     //These are strings that we will eventually need to deduce using the .csv files and the id of string 'testmsg'. The data types correspond to the following variables:
 	//mode, bmsAlive, ssbAlive, srvRegenAlive, esbAlive, inverter
      String msgdatatypes = "ACUMode, bool: 1, bool: 1, bool: 1, bool: 1, InverterType";
-        
-    //string msgdatatypes has ACUMode, booleans, and an InverterType. We will eventually need to deduce what these enums are 
+
+    //string msgdatatypes has ACUMode, booleans, and an InverterType. We will eventually need to deduce what these enums are
     //by using the file 'CAN_typedef_2019_17-format.csv' file.
      static String ACUdef = "enum ACUMode:uint8_t{ACUModeRDW,ACUModeWSC,DARE}";
      static String InvertDef = "enum InverterType:uint8_t{InverterTypeUnknown,Tritium,NLE}";
@@ -162,7 +162,7 @@ public class CANEnumParser {
 
 		//int data = Integer.parseInt(split0[1], 16);
 		//result = String.valueOf(data);
-		//result = Integer.toBinaryString(Integer.parseInt(split0[1], 16)); 
+		//result = Integer.toBinaryString(Integer.parseInt(split0[1], 16));
 		result = hexToBin(split0[1]);
 		result = String.format("%064d", new BigInteger(result));
 
@@ -177,15 +177,15 @@ public class CANEnumParser {
 		String[] split1 = split0[1].split(" ");  //split0[1] = " 12d#01c90100a819d400"
 		String[] split2 = split1[1].split("#");  //split1[1] = "12d#01c90100a819d400"
 		String idInHex = split2[0]; //take the 'left side' after splitting "12d#01c90100a819d400" on "#"
-		int ID = Integer.parseInt(idInHex,16); 
+		int ID = Integer.parseInt(idInHex,16);
 
 		return ID;
 	}
 
 	//Takes a CAN message "(1600453413.322000) canx 12d#01c90100a819d400" and returns the timestamp associated with it.
 	public static String parseTimestamp(String CANMessage) {
-		String[] split0 = CANMessage.split("\\)"); 
-		String[] split1 = split0[0].split("\\(");//split0[0] = "(1600453413.322000", split1[1] = "1600453413.322000" 
+		String[] split0 = CANMessage.split("\\)");
+		String[] split1 = split0[0].split("\\(");//split0[0] = "(1600453413.322000", split1[1] = "1600453413.322000"
 		String[] split2 = split1[1].split("\\.");
 
 		long time1 = Long.valueOf(split2[0]).longValue();
@@ -201,14 +201,14 @@ public class CANEnumParser {
 		return "temp";
 	}
 
-	
+
 
 	/*
 	 Using the ID of the message in combination with the CAN overview, we can figure out what data types are present in the current CAN message.
 	 E.g. in this case something along the lines of:
 	 (int timestamp, ACUMode mode, bool bmsAlive, bool ssbAlive, bool srvRegenAlive, bool esbAlive, InverterType inverter)
-	 
-	 Note that ideally we'd like to have a list that contains multiple different types in a specific order. 
+
+	 Note that ideally we'd like to have a list that contains multiple different types in a specific order.
 	 It therefore probably shouldn't return a List of Strings, but see it as a placeholder.
 	 */
 	public List<List<String>> parseOverview(int id, long timestamp, String CANOverview) {
@@ -218,9 +218,9 @@ public class CANEnumParser {
 	}
 
 	/*
-	We can determine which bits belong to which data as this has a structured order. 
+	We can determine which bits belong to which data as this has a structured order.
 	We will create a hashmap that links these as follows:
-	{(ACUMode mode, 00000001), (bool bmsAlive, 1), (bool ssbAlive, 0), 
+	{(ACUMode mode, 00000001), (bool bmsAlive, 1), (bool ssbAlive, 0),
 	(bool srvRegenAlive, 1), (bool esbAlive, 1), (InverterType inverter, 00000110)}
 
 	Note that we will probably save the timestamp and pass it along as a separate variable,
@@ -232,11 +232,11 @@ public class CANEnumParser {
 	endianness: if endianness is >= 1 the byte order is different. Each signal has a specific integer denoted to endianness, and this should thus be checked in messages.csv.
 
 	Lastly, all available data types are:
-	bool, bool:1, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, 
+	bool, bool:1, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float,
 	and OTHER (where OTHER is always an enum).
 	*/
 	public List<String> determineBits(List<String> l1, List<String> l2, String dataBytes, int endianness) {
-		
+
 		List<String> result = new ArrayList<String>();
 
 		printUniqueTypes(l1);
@@ -256,7 +256,7 @@ public class CANEnumParser {
 					result.add(dataBytes.substring(0,8)); //add bits to list3 (see overview on drive for a description of list3)
 					dataBytes = dataBytes.substring(8); //remove the byte from the overall String of bytes.
 				break;
-				
+
 				case "bool:1": //1 bit
 				//We need to check whether there are multiple "bool:1"s in a row. If there are we need to look within the same byte to find the correct corresponding bit.
 					int count = 0;
@@ -292,13 +292,13 @@ public class CANEnumParser {
 					}
 
 				break;
-				
-				case "int8_t": 
+
+				case "int8_t":
 					result.add(dataBytes.substring(0,8));
 					dataBytes = dataBytes.substring(8);
 					break;
-				
-				case "int16_t": 
+
+				case "int16_t":
 					if(endianness > 0) {
 						result.add(dataBytes.substring(0,16));
 						dataBytes = dataBytes.substring(16);
@@ -310,9 +310,9 @@ public class CANEnumParser {
 						dataBytes = dataBytes.substring(16);
 					}
 					break;
-				
-				
-				case "int32_t": 
+
+
+				case "int32_t":
 					if(endianness > 0) {
 						result.add(dataBytes.substring(0,32));
 						dataBytes = dataBytes.substring(32);
@@ -324,9 +324,9 @@ public class CANEnumParser {
 						result.add(temp);
 					}
 					break;
-				
-				
-				case "int64_t": 
+
+
+				case "int64_t":
 					if(endianness > 0) {
 						result.add(dataBytes);//is the only variable in the data, so string dataBytes does not need to be trimmed
 					} else {
@@ -341,10 +341,10 @@ public class CANEnumParser {
 						result.add(temp);
 					}
 					break;
-					
 
-				
-				case "float": 
+
+
+				case "float":
 					if (endianness > 0) {
 					result.add(dataBytes.substring(0,32));
 					dataBytes = dataBytes.substring(32);
@@ -357,7 +357,7 @@ public class CANEnumParser {
 					}
 					break;
 
-				default: 
+				default:
 					result.add(dataBytes.substring(0,8));
 					dataBytes = dataBytes.substring(8);
 					break;
@@ -386,8 +386,8 @@ public class CANEnumParser {
 	HashMap<String, HashMap<String, String>> enums = parseTypedef(); //the hashmap of enums with their corresponding byte sequence. See overview on the drive for details.
 
 	/* Finally, we use the hashmap created by determineBits() to determine what state the bytesequence
-	on the left partains. The integers and booleans all have set bit/byte sequences (see top of this java file), 
-	so those can be translated directly. The result should look as follows: 
+	on the left partains. The integers and booleans all have set bit/byte sequences (see top of this java file),
+	so those can be translated directly. The result should look as follows:
 
 	{
    "timestamp": "(1600453413.322000)"
@@ -402,7 +402,7 @@ public class CANEnumParser {
 	}
 
 	This is a specific format that allows for easier sending, receiving and parsing.
-	
+
 	As for what the lists are, please refer to the overview on google drive.
 	*/
 	public List<String> determineConcreteData(List<String> l1, List<String> l2, List<String> l3) {
@@ -426,7 +426,7 @@ public class CANEnumParser {
 						result.add("true");
 					}
 					break;
-				
+
 				case "bool:1": //1 bit
 					if(bytes.equals("0")) {
 						result.add("false");
@@ -434,68 +434,68 @@ public class CANEnumParser {
 						result.add("true");
 					}
 					break;
-				
-				case "uint8_t": 
+
+				case "uint8_t":
 					result.add(Integer.toString(Integer.parseInt(bytes, 2)));
 					break;
-				
-				case "uint16_t": 
+
+				case "uint16_t":
 					result.add(Integer.toString(Integer.parseInt(bytes, 2)));
 					break;
-						
-				case "uint32_t": 
-					result.add(Integer.toString(Integer.parseInt(bytes, 2)));
-					break;	
-				
-				case "uint64_t": 
+
+				case "uint32_t":
 					result.add(Integer.toString(Integer.parseInt(bytes, 2)));
 					break;
-					
-				case "int8_t": 
+
+				case "uint64_t":
+					result.add(Integer.toString(Integer.parseInt(bytes, 2)));
+					break;
+
+				case "int8_t":
 					String int8Value = ""; //final value to be calculated. Needs to be done in two steps: 1) determine if the value is negative or positive 2) determine value
 
 					if(bytes.substring(0,1).equals("1")) { //if the first bit is a '1' the value is negative.
 						int8Value = "-";
 					}
-					
+
 					int8Value.concat(Integer.toString(Integer.parseInt(bytes.substring(1), 2)));
 					result.add(int8Value);
 					break;
-				
-				case "int16_t": 
-					String int16Value = ""; 
 
-					if(bytes.substring(0,1).equals("1")) { 
+				case "int16_t":
+					String int16Value = "";
+
+					if(bytes.substring(0,1).equals("1")) {
 						int16Value = "-";
 					}
-					
-					int16Value.concat(Integer.toString(Integer.parseInt(bytes.substring(1), 2))); 
+
+					int16Value.concat(Integer.toString(Integer.parseInt(bytes.substring(1), 2)));
 					result.add(int16Value);
 					break;
-						
-				case "int32_t": 
-					String int32Value = ""; 
 
-					if(bytes.substring(0,1).equals("1")) { 
+				case "int32_t":
+					String int32Value = "";
+
+					if(bytes.substring(0,1).equals("1")) {
 						int32Value = "-";
 					}
-					
-					int32Value.concat(Integer.toString(Integer.parseInt(bytes.substring(1), 2))); 
+
+					int32Value.concat(Integer.toString(Integer.parseInt(bytes.substring(1), 2)));
 					result.add(int32Value);
-					break;	
-				
-				case "int64_t": 
+					break;
+
+				case "int64_t":
 					String int64Value = "";
 
-					if(bytes.substring(0,1).equals("1")) { 
+					if(bytes.substring(0,1).equals("1")) {
 						int64Value = "-";
 					}
-					
+
 					int64Value.concat(Integer.toString(Integer.parseInt(bytes.substring(1), 2)));
 					result.add(int64Value);
 					break;
-				
-				case "float": 
+
+				case "float":
 					int intBits = Integer.parseInt(bytes, 2);
 					Float floatValue = Float.intBitsToFloat(intBits);
 					String floatStringValue = floatValue.toString();

--- a/stellacanread-proxy/src/test/java/com/ste/emreparser/CANParserTest.java
+++ b/stellacanread-proxy/src/test/java/com/ste/emreparser/CANParserTest.java
@@ -1,0 +1,65 @@
+package com.ste.emreparser;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class CANParserTest {
+
+    // The instance variable that we'll use to call the functions on.
+    private CANParser cp;
+
+    // Instantiate a CANParser object
+    @Before
+    public void setUp() {
+        cp = new CANParser();
+    }
+
+    /**
+     * Tests that check the parseMessagesDefault method and the state of MessageObject
+     */
+    // Test that there are exactly 398 messages loaded in.
+    @Test
+    public void parseMessagesDefaultMessageAmount() {
+        // The amount of messages that should be in messages.csv, this excludes
+        // the 2 header lines that are present in messages.csv
+        int expectedMessageAmount = 398;
+
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+        assertEquals("Message list size: ", messageList.size(), expectedMessageAmount);
+    }
+
+    // A MessageObject should always have a name
+    @Test
+    public void parseMessagesDefaultIsMessageObject() {
+        // Parse message.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // Iterate through the list of messages and check if getName returns a String
+        for (MessageObject mo : messageList) {
+            // The condition that we're testing for, in this case that getName returns a String of
+            // length > 0
+            boolean condition = (mo.getName().length() > 0);
+            assertTrue("This message has a name: ", condition);
+        }
+    }
+    /**
+     * Tests that check the parsedTypedefsDefault method
+     */
+    // Test that there are exactly 65 typedefs loaded in.
+    @Test
+    public void parseTypedefsDefaultTypdefAmount() {
+        // The amount of typedefs that should be in typedefs.csv , this excludes
+        // the 1 header line that is present in typedefs.csv
+        int expectedTypedefAmount = 65;
+
+        // Parse typedefs.csv and assert that the expected amount of typedef objects are present
+        List<TypedefObject> typedefList = cp.parseTypedefsDefault();
+        assertEquals(typedefList.size(), expectedTypedefAmount);
+    }
+
+}

--- a/stellacanread-proxy/src/test/java/com/ste/emreparser/CANParserTest.java
+++ b/stellacanread-proxy/src/test/java/com/ste/emreparser/CANParserTest.java
@@ -33,9 +33,37 @@ public class CANParserTest {
         assertEquals("Message list size: ", messageList.size(), expectedMessageAmount);
     }
 
+    // Test if a MessageObject always has default values for each data type
+    @Test
+    public void messageObjectHasDefaultValues() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // For each typedefObject in the list check whether they have equal amount of arguments
+        // for the datatype array and the defaultvalues array.
+        for (MessageObject mo : messageList) {
+            assertEquals(mo.getDataTypes().length, mo.getDefaultValues().length);
+        }
+    }
+
+    // The default messages.csv file does not have a signal with id 3, test this
+    @Test
+    public void parseMessagesDefaultIncorrectID() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // The ID that SHOULD be missing
+        int badID = 3;
+
+        // Iterate through the list of message and make sure that id 3 is not among the messages
+        for (MessageObject mo: messageList) {
+            assertNotEquals(badID, Integer.parseInt(mo.getId()));
+        }
+    }
+
     // A MessageObject should always have a name
     @Test
-    public void parseMessagesDefaultIsMessageObject() {
+    public void parseMessagesDefaultHasName() {
         // Parse message.csv
         List<MessageObject> messageList = cp.parseMessagesDefault();
 
@@ -47,12 +75,82 @@ public class CANParserTest {
             assertTrue("This message has a name: ", condition);
         }
     }
+
+    // Check to see if messages with a certain ID indeed have the correct name
+    @Test
+    public void parseMessagesDefaultIDName1() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // The ID and name that are going to be checked
+        int id = 203;
+        String expectedName = "BMS_ContinuousCharging";
+
+        // Look through the list of messages for the relevant ID
+        for (MessageObject mo : messageList) {
+            if (Integer.parseInt(mo.getId()) == id) {
+                // ID was found, now assert that the names are correct
+                assertEquals(expectedName, mo.getName());
+            }
+        }
+    }
+
+    @Test
+    public void parseMessagesDefaultIDName2() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // The id and name that are going to be checked
+        int id = 305;
+        String expectedName = "ACU_ThrottlePedal";
+
+        // Look through the list of messages for the relevant ID
+        for (MessageObject mo : messageList) {
+            if (Integer.parseInt(mo.getId()) == id) {
+                // ID was found, now assert tghat the names are correct
+                assertEquals(expectedName, mo.getName());
+            }
+        }
+    }
+
+    @Test
+    public void parseMessagesDefaultIDName3() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // The id and name that are going to be checked
+        int id = 700106;
+        String expectedName = "Ch2_CVTimeout_Set";
+
+        // Look through the list of messages for the relevant ID
+        for (MessageObject mo : messageList) {
+            if (Integer.parseInt(mo.getId()) == id) {
+                // ID was found, now assert that the names are correct
+                assertEquals(expectedName, mo.getName());
+            }
+        }
+    }
+
+    // Each message should always have a field name for each data type.
+    // Test if each message has the same amount of data types and field names
+    @Test
+    public void parseMessagesDefaultEqualAmountOfFields () {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // For each message, the amount of data types should be equal to the amount of field names
+        for (MessageObject mo : messageList) {
+            boolean hasEqualLength = (mo.getFieldNames().length == mo.getDataTypes().length);
+            assertTrue(hasEqualLength);
+        }
+    }
+
     /**
-     * Tests that check the parsedTypedefsDefault method
+     * Tests that check the parsedTypedefsDefault method and the TypedefObject class
      */
     // Test that there are exactly 65 typedefs loaded in.
     @Test
-    public void parseTypedefsDefaultTypdefAmount() {
+    public void parseTypedefsDefaultTypedefAmount() {
         // The amount of typedefs that should be in typedefs.csv , this excludes
         // the 1 header line that is present in typedefs.csv
         int expectedTypedefAmount = 65;
@@ -60,6 +158,24 @@ public class CANParserTest {
         // Parse typedefs.csv and assert that the expected amount of typedef objects are present
         List<TypedefObject> typedefList = cp.parseTypedefsDefault();
         assertEquals(typedefList.size(), expectedTypedefAmount);
+    }
+
+    // Test if an exception is thrown if a different typedef enum is used
+    @Test(expected = IllegalArgumentException.class)
+    public void parseTypedefsDefaultIllegalType1() {
+        // Try to create an object with type uint16_t. This is expected to fail
+        new TypedefObject("AVCState",
+            "enum class AVCState : uint16_t {Unknown, Startup, ConvertersEnabled, ManualOverride, Failure}",
+            "State of the AVC");
+    }
+
+    // Test if an exception is thrown if a nonsensical type is used
+    @Test(expected = IllegalArgumentException.class)
+    public void parseTypedefsDefaultIllegalType2() {
+        // Try to create an object with type uint16_t. This is expected to fail
+        new TypedefObject("AVCState",
+            "enum class AVCState : hjklksdg {Unknown, Startup, ConvertersEnabled, ManualOverride, Failure}",
+            "State of the AVC");
     }
 
 }

--- a/stellacanread-proxy/src/test/java/com/ste/emreparser/CANParserTest.java
+++ b/stellacanread-proxy/src/test/java/com/ste/emreparser/CANParserTest.java
@@ -145,6 +145,116 @@ public class CANParserTest {
         }
     }
 
+    /* Check some expected data units */
+    // Check expected data units for ID 30
+    @Test
+    public void parseMessagesDefaultUnits1() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // The expected data units for ID 30
+        int id = 30;
+        String[] expectedUnits = new String[] {"V", "A"};
+
+        // Get the MessageObject with ID 30 and check the expected data units
+        for (MessageObject mo : messageList) {
+            if (Integer.parseInt(mo.getId()) == id) {
+                assertArrayEquals(expectedUnits, mo.getUnits());
+            }
+        }
+    }
+
+    // Check expected data units for ID 220
+    @Test
+    public void parseMessagesDefaultUnits2() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // The expected data units for ID 220
+        int id = 220;
+        String[] expectedUnits = new String[] {"-", "-", "-"};
+
+        // Get the MessageObject with ID 220 and check the expected data units
+        for (MessageObject mo : messageList) {
+            if (Integer.parseInt(mo.getId()) == id) {
+                assertArrayEquals(expectedUnits, mo.getUnits());
+            }
+        }
+    }
+
+    // Check expected data units for ID 1222
+    @Test
+    public void parseMessagesDefaultUnits3() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // The expected data units for ID 1222
+        int id = 1222;
+        String[] expectedUnits = new String[] {"state","%","Hz"};
+
+        // Get the MessageObject with ID 1222 and check the expected data units
+        for (MessageObject mo : messageList) {
+            if (Integer.parseInt(mo.getId()) == id) {
+                assertArrayEquals(expectedUnits, mo.getUnits());
+            }
+        }
+    }
+
+    /* Check some expected data types */
+    // Check expected data types for ID 71
+    @Test
+    public void parseMessagesDefaultTypes1() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // The expected data types for ID 71
+        int id = 71;
+        String[] expectedTypes = new String[] {"int16_t", "int16_t", "int16_t", "bool"};
+
+        // Get the MessageObject with ID 71 and check the expected data units
+        for (MessageObject mo : messageList) {
+            if (Integer.parseInt(mo.getId()) == id) {
+                assertArrayEquals(expectedTypes, mo.getDataTypes());
+            }
+        }
+    }
+
+    // Check expected data types for ID 232
+    @Test
+    public void parseMessagesDefaultTypes2() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // The expected data types for ID 232
+        int id = 232;
+        String[] expectedTypes = new String[] {"int64_t"};
+
+        // Get the MessageObject with ID 232 and check the expected data units
+        for (MessageObject mo : messageList) {
+            if (Integer.parseInt(mo.getId()) == id) {
+                assertArrayEquals(expectedTypes, mo.getDataTypes());
+            }
+        }
+    }
+
+    // Check expected data types for ID 700109
+    @Test
+    public void parseMessagesDefaultTypes3() {
+        // Parse messages.csv
+        List<MessageObject> messageList = cp.parseMessagesDefault();
+
+        // The expected data types for ID 700109
+        int id = 700109;
+        String[] expectedTypes = new String[] {"MW3200FaultFlags"};
+
+        // Get the MessageObject with ID 700109 and check the expected data units
+        for (MessageObject mo : messageList) {
+            if (Integer.parseInt(mo.getId()) == id) {
+                assertArrayEquals(expectedTypes, mo.getDataTypes());
+            }
+        }
+    }
+
     /**
      * Tests that check the parsedTypedefsDefault method and the TypedefObject class
      */


### PR DESCRIPTION
## Proposed changes

Upped the total tests for CANParser.java, MessageObject.java and TypedefObject.java to 17 tests. 
Fixed an issue with leading and trailing whitespaces that remained in the String arrays of a Messageobject

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
Unit tests are contained in CANParserTest.java. These can be run using your IDE of choice.

### Unit testing

These tests mainly do sanity checks of the reading in of messages.csv and typedefs.csv. So an example of a test would be: "Is it correct that a message with ID 13 indeed has the data types "int16_t, int16_t, uint8_t, uint8_t""?
